### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: PR Tests with Docker
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ghackev/transactions/security/code-scanning/1](https://github.com/ghackev/transactions/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not require write access to the repository, we can set the permissions to `contents: read` at the root level. This ensures that all jobs in the workflow inherit the least privilege required.

The `permissions` block should be added at the top level of the workflow, right after the `name` field. This change will limit the permissions of the `GITHUB_TOKEN` to read-only access for repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
